### PR TITLE
OData ライブラリ内でのメモリリークを回避するための可能な限りの修正

### DIFF
--- a/HiyoshiCfhClient/Client.cs
+++ b/HiyoshiCfhClient/Client.cs
@@ -48,9 +48,10 @@ namespace HiyoshiCfhClient
             _DebugConsole = debugConsole;
         }
 
-        private void ResetContext()
+        internal void ResetContext()
         {
             Context = new Container(new Uri("https://hiyoshicfhweb.azurewebsites.net/odata"));
+            GC.Collect();
             if (TokenType != null && AccessToken != null)
             {
                 Context.SendingRequest2 += (sender, eventArgs) =>

--- a/HiyoshiCfhClient/Client.cs
+++ b/HiyoshiCfhClient/Client.cs
@@ -52,7 +52,7 @@ namespace HiyoshiCfhClient
         {
             Context = new Container(new Uri("https://hiyoshicfhweb.azurewebsites.net/odata"));
             GC.Collect();
-            Context.MergeOption = MergeOption.NoTracking;
+            Context.MergeOption = MergeOption.PreserveChanges;
             if (TokenType != null && AccessToken != null)
             {
                 Context.SendingRequest2 += (sender, eventArgs) =>

--- a/HiyoshiCfhClient/Client.cs
+++ b/HiyoshiCfhClient/Client.cs
@@ -104,6 +104,7 @@ namespace HiyoshiCfhClient
                 try
                 {
                     Context.SaveChanges();
+                    DetachAll();
                 }
                 catch (DataServiceRequestException ex)
                 {
@@ -153,6 +154,7 @@ namespace HiyoshiCfhClient
             try
             {
                 Context.SaveChanges();
+                DetachAll();
             }
             catch (DataServiceRequestException ex)
             {
@@ -188,6 +190,7 @@ namespace HiyoshiCfhClient
                     }
                 }
                 Context.SaveChanges();
+                DetachAll();
             }
             catch (Exception ex)
             {
@@ -205,6 +208,7 @@ namespace HiyoshiCfhClient
                     (x, y) => x.Id == y.ShipInfoId, x => new WebShipInfo(x),
                     x => Context.AddToShipInfoes(x));
                 Context.SaveChanges();
+                DetachAll();
             }
             catch (Exception ex)
             {
@@ -222,6 +226,7 @@ namespace HiyoshiCfhClient
                     (x, y) => x.Id == y.SlotItemInfoId, x => new WebSlotItemInfo(x),
                     x => Context.AddToSlotItemInfoes(x));
                 Context.SaveChanges();
+                DetachAll();
             }
             catch (Exception ex)
             {
@@ -251,6 +256,7 @@ namespace HiyoshiCfhClient
                         );
                         OutDebugConsole("Saving ship data");
                         Context.SaveChanges();
+                        DetachAll();
                         OutDebugConsole("Saved ship data");
                     }
                     catch (DataServiceRequestException ex)
@@ -289,6 +295,7 @@ namespace HiyoshiCfhClient
                         );
                         OutDebugConsole("Saving SlotItem data");
                         Context.SaveChanges();
+                        DetachAll();
                         OutDebugConsole("Saved SlotItem data");
                     }
                     catch (DataServiceRequestException ex)
@@ -325,11 +332,8 @@ namespace HiyoshiCfhClient
                     );
                     OutDebugConsole("Saving quest data");
                     Context.SaveChanges();
+                    DetachAll();
                     OutDebugConsole("Saved quest data");
-                    foreach (var quest in quests)
-                    {
-                        Context.Detach(quest);
-                    }
                 }
                 catch (DataServiceRequestException ex)
                 {
@@ -354,6 +358,7 @@ namespace HiyoshiCfhClient
                     record.AdmiralId = Admiral.AdmiralId;
                     Context.AddToMaterialRecords(record);
                     Context.SaveChanges();
+                    DetachAll();
                 }
                 catch (DataServiceRequestException ex)
                 {
@@ -416,6 +421,19 @@ namespace HiyoshiCfhClient
                     OutDebugConsole("Add: " + local.ToString());
                     addOData(createOData(local));
                 }
+            }
+        }
+
+        void DetachAll()
+        {
+            foreach (var entity in Context.Entities.ToList())
+            {
+                Context.Detach(entity.Entity);
+            }
+
+            foreach (var link in Context.Links.ToList())
+            {
+                Context.DetachLink(link.Source, link.SourceProperty, link.Target);
             }
         }
     }

--- a/HiyoshiCfhClient/Client.cs
+++ b/HiyoshiCfhClient/Client.cs
@@ -52,6 +52,7 @@ namespace HiyoshiCfhClient
         {
             Context = new Container(new Uri("https://hiyoshicfhweb.azurewebsites.net/odata"));
             GC.Collect();
+            Context.MergeOption = MergeOption.NoTracking;
             if (TokenType != null && AccessToken != null)
             {
                 Context.SendingRequest2 += (sender, eventArgs) =>

--- a/HiyoshiCfhClient/HiyoshiCfhClient.csproj
+++ b/HiyoshiCfhClient/HiyoshiCfhClient.csproj
@@ -71,16 +71,20 @@
       <HintPath>..\packages\LivetCask.1.3.1.0\lib\net45\Microsoft.Expression.Interactions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.OData.Client, Version=7.4.1.20214, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.OData.Client.7.4.1\lib\net45\Microsoft.OData.Client.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\odata.net\bin\AnyCPU\Debug\Product\Desktop\Microsoft.OData.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.OData.Core, Version=7.4.1.20214, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.OData.Core.7.4.1\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\odata.net\bin\AnyCPU\Debug\Product\Desktop\Microsoft.OData.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.OData.Edm, Version=7.4.1.20214, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.OData.Edm.7.4.1\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\odata.net\bin\AnyCPU\Debug\Product\Desktop\Microsoft.OData.Edm.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Spatial, Version=7.4.1.20214, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Spatial.7.4.1\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\odata.net\bin\AnyCPU\Debug\Product\Desktop\Microsoft.Spatial.dll</HintPath>
     </Reference>
     <Reference Include="Nekoxy, Version=1.5.3.21, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Nekoxy.1.5.3.21\lib\net45\Nekoxy.dll</HintPath>

--- a/HiyoshiCfhClient/HiyoshiCfhClient.csproj
+++ b/HiyoshiCfhClient/HiyoshiCfhClient.csproj
@@ -70,21 +70,17 @@
     <Reference Include="Microsoft.Expression.Interactions, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\LivetCask.1.3.1.0\lib\net45\Microsoft.Expression.Interactions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.OData.Client, Version=7.4.1.20214, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\odata.net\bin\AnyCPU\Debug\Product\Desktop\Microsoft.OData.Client.dll</HintPath>
+    <Reference Include="Microsoft.OData.Client, Version=7.4.3.20321, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.OData.Client.7.4.3\lib\net45\Microsoft.OData.Client.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.OData.Core, Version=7.4.1.20214, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\odata.net\bin\AnyCPU\Debug\Product\Desktop\Microsoft.OData.Core.dll</HintPath>
+    <Reference Include="Microsoft.OData.Core, Version=7.4.3.20321, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.OData.Core.7.4.3\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.OData.Edm, Version=7.4.1.20214, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\odata.net\bin\AnyCPU\Debug\Product\Desktop\Microsoft.OData.Edm.dll</HintPath>
+    <Reference Include="Microsoft.OData.Edm, Version=7.4.3.20321, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.OData.Edm.7.4.3\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Spatial, Version=7.4.1.20214, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\odata.net\bin\AnyCPU\Debug\Product\Desktop\Microsoft.Spatial.dll</HintPath>
+    <Reference Include="Microsoft.Spatial, Version=7.4.3.20321, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Spatial.7.4.3\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
     </Reference>
     <Reference Include="Nekoxy, Version=1.5.3.21, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Nekoxy.1.5.3.21\lib\net45\Nekoxy.dll</HintPath>

--- a/HiyoshiCfhClient/ViewModels/ClientViewModel.cs
+++ b/HiyoshiCfhClient/ViewModels/ClientViewModel.cs
@@ -114,6 +114,7 @@ namespace HiyoshiCfhClient.ViewModels
         {
             if (OrganizationListener == null || ItemyardListener == null)
             {
+                OutDebugConsole("InitHandlers");
                 #region 艦娘の変更検知
                 OrganizationListener = new PropertyChangedEventListener(KanColleClient.Current.Homeport.Organization);
                 OrganizationListener.RegisterHandler(() => KanColleClient.Current.Homeport.Organization.Ships,
@@ -174,6 +175,17 @@ namespace HiyoshiCfhClient.ViewModels
                 #endregion
                 IsInited = true;
             }
+        }
+
+        public void ResetHandlers()
+        {
+            OutDebugConsole("ResetHandlers");
+            OrganizationListener.Dispose();
+            OrganizationListener = null;
+            ItemyardListener.Dispose();
+            ItemyardListener = null;
+            IsInited = false;
+            InitHandlers();
         }
 
         private async void MaterialsChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)

--- a/HiyoshiCfhClient/ViewModels/ClientViewModel.cs
+++ b/HiyoshiCfhClient/ViewModels/ClientViewModel.cs
@@ -90,6 +90,7 @@ namespace HiyoshiCfhClient.ViewModels
         PropertyChangedEventListener ItemyardListener = null;
         Client Client = null;
         QuestsTracker QuestsTracker;
+        IDisposable QuestSubscription;
 
         public ClientViewModel()
         {
@@ -165,7 +166,7 @@ namespace HiyoshiCfhClient.ViewModels
                 #endregion
                 #region 任務の取得検知
                 var proxy = KanColleClient.Current.Proxy;
-                proxy.api_get_member_questlist
+                QuestSubscription = proxy.api_get_member_questlist
                     .Select(QuestsTracker.QuestListSerialize)
                     .Where(x => x != null && x.api_count >= 0)
                     .Subscribe(async x => { await this.HandleQuests(x); });
@@ -184,6 +185,8 @@ namespace HiyoshiCfhClient.ViewModels
             OrganizationListener = null;
             ItemyardListener.Dispose();
             ItemyardListener = null;
+            KanColleClient.Current.Homeport.Materials.PropertyChanged -= MaterialsChanged;
+            QuestSubscription.Dispose();
             IsInited = false;
             InitHandlers();
         }

--- a/HiyoshiCfhClient/ViewModels/ClientViewModel.cs
+++ b/HiyoshiCfhClient/ViewModels/ClientViewModel.cs
@@ -3,8 +3,8 @@ using Grabacr07.KanColleWrapper.Models.Raw;
 using HiyoshiCfhClient.Models;
 using HiyoshiCfhClient.Utils;
 using Livet;
-using Livet.EventListeners;
 using Livet.Messaging;
+using StatefulModel.EventListeners;
 using System;
 using System.IO;
 using System.Reactive.Linq;
@@ -100,7 +100,7 @@ namespace HiyoshiCfhClient.ViewModels
             TokenType = Settings.Current.TokenType;
             EnableAutoUpdate = true;
             var kccListener = new PropertyChangedEventListener(KanColleClient.Current);
-            kccListener.RegisterHandler(() => KanColleClient.Current.IsStarted, (_, __) =>
+            kccListener.RegisterHandler("IsStarted", (_, __) =>
             {
                 if (!IsInited && KanColleClient.Current.IsStarted)
                 {
@@ -117,7 +117,7 @@ namespace HiyoshiCfhClient.ViewModels
                 OutDebugConsole("InitHandlers");
                 #region 艦娘の変更検知
                 OrganizationListener = new PropertyChangedEventListener(KanColleClient.Current.Homeport.Organization);
-                OrganizationListener.RegisterHandler(() => KanColleClient.Current.Homeport.Organization.Ships,
+                OrganizationListener.RegisterHandler("Ships",
                 async (s, h) =>
                 {
                     try
@@ -144,7 +144,7 @@ namespace HiyoshiCfhClient.ViewModels
                 #endregion
                 #region 装備の変更検知
                 ItemyardListener = new PropertyChangedEventListener(KanColleClient.Current.Homeport.Itemyard);
-                ItemyardListener.RegisterHandler(() => KanColleClient.Current.Homeport.Itemyard.SlotItems,
+                ItemyardListener.RegisterHandler("SlotItems",
                 async (s, h) =>
                 {
                     try

--- a/HiyoshiCfhClient/ViewModels/ClientViewModel.cs
+++ b/HiyoshiCfhClient/ViewModels/ClientViewModel.cs
@@ -361,6 +361,14 @@ namespace HiyoshiCfhClient.ViewModels
             PrepareClient();
         }
 
+        public void ResetContext()
+        {
+            if (Client != null)
+            {
+                Client.ResetContext();
+            }
+        }
+
         void InitClient()
         {
             if (CheckToken())

--- a/HiyoshiCfhClient/ViewModels/ClientViewModel.cs
+++ b/HiyoshiCfhClient/ViewModels/ClientViewModel.cs
@@ -351,6 +351,13 @@ namespace HiyoshiCfhClient.ViewModels
             }
         }
 
+        public void ResetClient()
+        {
+            OutDebugConsole("ResetClient");
+            Client = null;
+            PrepareClient();
+        }
+
         void InitClient()
         {
             if (CheckToken())

--- a/HiyoshiCfhClient/Views/ClientView.xaml
+++ b/HiyoshiCfhClient/Views/ClientView.xaml
@@ -83,6 +83,13 @@
                             </i:EventTrigger>
                         </i:Interaction.Triggers>
                     </Button>
+                    <Button x:Name="ResetClientButton" Content="Reset client" Margin="10,0,0,0">
+                        <i:Interaction.Triggers>
+                            <i:EventTrigger EventName="Click">
+                                <ei:CallMethodAction TargetObject="{Binding}" MethodName="ResetClient"/>
+                            </i:EventTrigger>
+                        </i:Interaction.Triggers>
+                    </Button>
                 </StackPanel>
             </StackPanel>
             <TextBox x:Name="DebugConsole" IsReadOnly="True" BorderThickness="0" TextWrapping="Wrap" Text="{Binding DebugConsole}" Grid.Row="2" Background="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}" Margin="10" Foreground="{DynamicResource {x:Static SystemColors.WindowBrushKey}}" />

--- a/HiyoshiCfhClient/Views/ClientView.xaml
+++ b/HiyoshiCfhClient/Views/ClientView.xaml
@@ -90,6 +90,13 @@
                             </i:EventTrigger>
                         </i:Interaction.Triggers>
                     </Button>
+                    <Button x:Name="ResetContextButton" Content="Reset context" Margin="10,0,0,0">
+                        <i:Interaction.Triggers>
+                            <i:EventTrigger EventName="Click">
+                                <ei:CallMethodAction TargetObject="{Binding}" MethodName="ResetContext"/>
+                            </i:EventTrigger>
+                        </i:Interaction.Triggers>
+                    </Button>
                 </StackPanel>
             </StackPanel>
             <TextBox x:Name="DebugConsole" IsReadOnly="True" BorderThickness="0" TextWrapping="Wrap" Text="{Binding DebugConsole}" Grid.Row="2" Background="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}" Margin="10" Foreground="{DynamicResource {x:Static SystemColors.WindowBrushKey}}" />

--- a/HiyoshiCfhClient/Views/ClientView.xaml
+++ b/HiyoshiCfhClient/Views/ClientView.xaml
@@ -62,17 +62,24 @@
                     <TextBlock Text="{Binding AccessToken}" VerticalAlignment="Center" Margin="0" />
                 </StackPanel>
                 <StackPanel Orientation="Horizontal">
-                    <Button x:Name="ClearConsoleButton" Content="コンソールのクリア" Margin="10,0">
+                    <Button x:Name="ClearConsoleButton" Content="コンソールのクリア" Margin="10,0,0,0">
                         <i:Interaction.Triggers>
                             <i:EventTrigger EventName="Click">
                                 <ei:CallMethodAction TargetObject="{Binding}" MethodName="ClearConsole"/>
                             </i:EventTrigger>
                         </i:Interaction.Triggers>
                     </Button>
-                    <Button x:Name="WrackTokenButton" Content="トークンを破壊">
+                    <Button x:Name="WrackTokenButton" Content="トークンを破壊" Margin="10,0,0,0">
                         <i:Interaction.Triggers>
                             <i:EventTrigger EventName="Click">
                                 <ei:CallMethodAction TargetObject="{Binding}" MethodName="WrackToken"/>
+                            </i:EventTrigger>
+                        </i:Interaction.Triggers>
+                    </Button>
+                    <Button x:Name="ResetHandlersButton" Content="Reset handler" Margin="10,0,0,0">
+                        <i:Interaction.Triggers>
+                            <i:EventTrigger EventName="Click">
+                                <ei:CallMethodAction TargetObject="{Binding}" MethodName="ResetHandlers"/>
                             </i:EventTrigger>
                         </i:Interaction.Triggers>
                     </Button>

--- a/HiyoshiCfhClient/packages.config
+++ b/HiyoshiCfhClient/packages.config
@@ -14,6 +14,10 @@
   <package id="MetroRadiance.Core" version="2.2.1" targetFramework="net46" />
   <package id="MetroTrilithon" version="0.2.0" targetFramework="net46" />
   <package id="MetroTrilithon.Desktop" version="0.2.3" targetFramework="net46" />
+  <package id="Microsoft.OData.Client" version="7.4.3" targetFramework="net46" />
+  <package id="Microsoft.OData.Core" version="7.4.3" targetFramework="net46" />
+  <package id="Microsoft.OData.Edm" version="7.4.3" targetFramework="net46" />
+  <package id="Microsoft.Spatial" version="7.4.3" targetFramework="net46" />
   <package id="Nekoxy" version="1.5.3.21" targetFramework="net46" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net46" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net46" />

--- a/HiyoshiCfhClient/packages.config
+++ b/HiyoshiCfhClient/packages.config
@@ -14,10 +14,6 @@
   <package id="MetroRadiance.Core" version="2.2.1" targetFramework="net46" />
   <package id="MetroTrilithon" version="0.2.0" targetFramework="net46" />
   <package id="MetroTrilithon.Desktop" version="0.2.3" targetFramework="net46" />
-  <package id="Microsoft.OData.Client" version="7.4.1" targetFramework="net46" />
-  <package id="Microsoft.OData.Core" version="7.4.1" targetFramework="net46" />
-  <package id="Microsoft.OData.Edm" version="7.4.1" targetFramework="net46" />
-  <package id="Microsoft.Spatial" version="7.4.1" targetFramework="net46" />
   <package id="Nekoxy" version="1.5.3.21" targetFramework="net46" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net46" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net46" />


### PR DESCRIPTION
#11 を修正しようと、様々な変更を加えたが、ライブラリ内の問題のため、最終的な解決には至らなかった。

ただし、 #6 のエラーは見受けられなくなった。